### PR TITLE
Sonar fixes

### DIFF
--- a/src/Blorc.OpenIdConnect.DemoApp.Server/Controllers/WeatherForecastController.cs
+++ b/src/Blorc.OpenIdConnect.DemoApp.Server/Controllers/WeatherForecastController.cs
@@ -19,13 +19,6 @@
             "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching",
         };
 
-        private readonly ILogger<WeatherForecastController> _logger;
-
-        public WeatherForecastController(ILogger<WeatherForecastController> logger)
-        {
-            _logger = logger;
-        }
-
         [HttpGet]
         [Authorize]
         public IEnumerable<WeatherForecast> Get()

--- a/src/Blorc.OpenIdConnect.DemoApp.Server/Pages/Error.cshtml.cs
+++ b/src/Blorc.OpenIdConnect.DemoApp.Server/Pages/Error.cshtml.cs
@@ -1,27 +1,15 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Blorc.OpenIdConnect.DemoApp2.Server.Pages
+﻿namespace Blorc.OpenIdConnect.DemoApp2.Server.Pages
 {
+    using System.Diagnostics;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.RazorPages;
+
     [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
     public class ErrorModel : PageModel
     {
         public string RequestId { get; set; }
 
         public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
-
-        private readonly ILogger<ErrorModel> _logger;
-
-        public ErrorModel(ILogger<ErrorModel> logger)
-        {
-            _logger = logger;
-        }
 
         public void OnGet()
         {

--- a/src/Blorc.OpenIdConnect.DemoApp.Server/Pages/Shared/_Layout.cshtml
+++ b/src/Blorc.OpenIdConnect.DemoApp.Server/Pages/Shared/_Layout.cshtml
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <meta charset="utf-8" />

--- a/src/Blorc.OpenIdConnect.DemoApp.Server/Program.cs
+++ b/src/Blorc.OpenIdConnect.DemoApp.Server/Program.cs
@@ -3,7 +3,7 @@
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Hosting;
 
-    public class Program
+    public static class Program
     {
         public static IHostBuilder CreateHostBuilder(string[] args)
         {

--- a/src/Blorc.OpenIdConnect.DemoApp/Services/WeatherForecastHttpClient.cs
+++ b/src/Blorc.OpenIdConnect.DemoApp/Services/WeatherForecastHttpClient.cs
@@ -25,6 +25,7 @@
             }
             catch
             {
+                // ignored
             }
 
             return forecasts;

--- a/src/Blorc.OpenIdConnect.DemoApp/wwwroot/index.html
+++ b/src/Blorc.OpenIdConnect.DemoApp/wwwroot/index.html
@@ -1,5 +1,5 @@
-﻿<!DOCTYPE html>
-<html>
+<!DOCTYPE html>
+<html lang="en">
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />

--- a/src/Blorc.OpenIdConnect.Tests/Extensions/ObjectExtensionsFacts.cs
+++ b/src/Blorc.OpenIdConnect.Tests/Extensions/ObjectExtensionsFacts.cs
@@ -70,7 +70,7 @@
 
                 var claims = users.AsClaims().ToList();
 
-                Assert.AreEqual(12, claims.Count);
+                Assert.AreEqual(14, claims.Count);
             }
 
             [Test]
@@ -82,9 +82,9 @@
                     Profile = new Profile
                     {
                         Roles = new[]
-                                                     {
-                                                         "Administrator", "System Administrator"
-                                                     },
+                        {
+                            "Administrator", "System Administrator"
+                        },
                         Email = "jane.doe@blorc.com",
                         EmailVerified = true,
                         FamilyName = "Doe",
@@ -108,10 +108,11 @@
 
                 complexType.Users.Add(user);
                 complexType.Users.Add(user);
+                complexType.Users.Add(null);
 
                 var claims = complexType.AsClaims().ToList();
 
-                Assert.AreEqual(16, claims.Count);
+                Assert.AreEqual(18, claims.Count);
             }
 
             public class ComplexType

--- a/src/Blorc.OpenIdConnect.Tests/Services/UserManagerFacts.cs
+++ b/src/Blorc.OpenIdConnect.Tests/Services/UserManagerFacts.cs
@@ -33,7 +33,7 @@
                 navigationManagerStub.SetField("_isInitialized", true);
                 navigationManagerStub.SetField("_uri", "http://localhost");
 
-                var userManager = new UserManager(jsRuntimeMock.Object, navigationManagerStub.Instance, new Mock<IConfigurationService>().Object, oidcProviderOptions);
+                var userManager = new UserManager(jsRuntimeMock.Object, navigationManagerStub.Instance, oidcProviderOptions);
 
                 var user = await userManager.GetUserAsync<User<Profile>>();
 
@@ -76,7 +76,7 @@
                 navigationManagerStub.SetField("_isInitialized", true);
                 navigationManagerStub.SetField("_uri", "http://localhost");
 
-                var userManager = new UserManager(jsRuntimeMock.Object, navigationManagerStub.Instance, new Mock<IConfigurationService>().Object, oidcProviderOptions);
+                var userManager = new UserManager(jsRuntimeMock.Object, navigationManagerStub.Instance, oidcProviderOptions);
 
                 var user = await userManager.GetUserAsync<User<Profile>>();
 

--- a/src/Blorc.OpenIdConnect/Attributes/ClaimTypeAttribute.cs
+++ b/src/Blorc.OpenIdConnect/Attributes/ClaimTypeAttribute.cs
@@ -2,6 +2,7 @@
 {
     using System;
 
+    [AttributeUsage(AttributeTargets.Property)]
     public class ClaimTypeAttribute : Attribute
     {
         public ClaimTypeAttribute(string claimType)

--- a/src/Blorc.OpenIdConnect/Extensions/EnumerableExtensions.cs
+++ b/src/Blorc.OpenIdConnect/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace Blorc.OpenIdConnect
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+
+    public static class EnumerableExtensions
+    {
+        public static IEnumerable<Claim> AsClaims(this IEnumerable items, string claimType)
+        {
+            return items.OfType<object>().SelectMany(item => item.AsClaims(claimType));
+        }
+    }
+}

--- a/src/Blorc.OpenIdConnect/Services/Extensions/DocumentServiceExtensions.cs
+++ b/src/Blorc.OpenIdConnect/Services/Extensions/DocumentServiceExtensions.cs
@@ -8,8 +8,6 @@
     {
         public static async Task InjectOpenIdConnectAsync(this IDocumentService documentService)
         {
-            // Argument.IsNotNull(() => documentService);
-
             await documentService.InjectAssemblyScriptFileAsync(typeof(DocumentServiceExtensions).Assembly, "oidc-client.min.js");
             await documentService.InjectAssemblyScriptFileAsync(typeof(DocumentServiceExtensions).Assembly, "oidc-client-interop.js");
         }

--- a/src/Blorc.OpenIdConnect/Services/UserManager.cs
+++ b/src/Blorc.OpenIdConnect/Services/UserManager.cs
@@ -15,26 +15,23 @@
     {
         private static readonly string[] ExpectedParameters = { "state", "session_state", "code", "access_token", "id_token", "token_type" };
 
-        private readonly IConfigurationService _configurationService;
-
         private readonly IJSRuntime _jsRuntime;
 
         private readonly NavigationManager _navigationManager;
 
         private readonly Dictionary<Type, object> _usersCache = new Dictionary<Type, object>();
 
-        public UserManager(IJSRuntime jsRuntime, NavigationManager navigationManager, IConfigurationService configurationService, OidcProviderOptions options)
-            : this(jsRuntime, navigationManager, configurationService)
+        public UserManager(IJSRuntime jsRuntime, NavigationManager navigationManager, OidcProviderOptions options)
+            : this(jsRuntime, navigationManager)
         {
             var serializedOptions = JsonSerializer.Serialize(options);
             Configuration = JsonSerializer.Deserialize<Dictionary<string, object>>(serializedOptions);
         }
 
-        public UserManager(IJSRuntime jsRuntime, NavigationManager navigationManager, IConfigurationService configurationService)
+        public UserManager(IJSRuntime jsRuntime, NavigationManager navigationManager)
         {
             _jsRuntime = jsRuntime;
             _navigationManager = navigationManager;
-            _configurationService = configurationService;
         }
 
         public Dictionary<string, object> Configuration { get; private set; }
@@ -118,20 +115,6 @@
 
         private async Task InitializeAsync()
         {
-            // TODO: Deprecate this.
-            if (Configuration is null)
-            {
-                var configuration = await _configurationService.GetSectionAsync<Dictionary<string, string>>("identityserver");
-                if (configuration is not null)
-                {
-                    Configuration = new Dictionary<string, object>();
-                    foreach (var pair in configuration)
-                    {
-                        configuration[pair.Key] = pair.Value;
-                    }
-                }
-            }
-
             if (Configuration is not null)
             {
                 await InitializeAsync(() => Task.FromResult(Configuration));

--- a/src/Blorc.OpenIdConnect/wwwroot/oidc-client-interop.js
+++ b/src/Blorc.OpenIdConnect/wwwroot/oidc-client-interop.js
@@ -16,7 +16,7 @@
 
                 if (config.automaticSilentRenew && (config.silent_redirect_uri === null || config.silent_redirect_uri === "")) {
                     config.silent_redirect_uri = window.location.protocol + "//" + window.location.hostname;
-                    if (window.location.port !== 80 && window.location.port !== 443) {
+                    if (window.location.port != 80 && window.location.port != 443) {
                         config.silent_redirect_uri += ":" + window.location.port;
                     }
 

--- a/src/Blorc.OpenIdConnect/wwwroot/oidc-client-interop.js
+++ b/src/Blorc.OpenIdConnect/wwwroot/oidc-client-interop.js
@@ -47,7 +47,7 @@
                 }
 
                 var self = this;
-                return new Promise((resolve, reject) => {
+                return new Promise((resolve, _reject) => {
                     self.userManager.signinRedirectCallback().then(function(u) {
                         resolve(u !== null);
                     }).catch(function(e) {
@@ -71,7 +71,7 @@
                 }
 
                 var self = this;
-                return new Promise((resolve, reject) => {
+                return new Promise((resolve, _reject) => {
                     self.userManager.getUser().then(function(u) {
                         self.SetCurrentUser(u);
                         resolve(u);
@@ -90,7 +90,7 @@
                 }
 
                 var self = this;
-                return new Promise((resolve, reject) => {
+                return new Promise((resolve, _reject) => {
                     self.userManager.signinRedirect();
                     resolve(true);
                 });
@@ -102,7 +102,7 @@
                 }
 
                 var self = this;
-                return new Promise((resolve, reject) => {
+                return new Promise((resolve, _reject) => {
                     self.userManager.signoutRedirect();
                     return resolve(true);
                 });

--- a/src/Blorc.OpenIdConnect/wwwroot/oidc-client-interop.js
+++ b/src/Blorc.OpenIdConnect/wwwroot/oidc-client-interop.js
@@ -25,7 +25,7 @@
 
                 this.userManager = new oidc.UserManager(config);
                 if (config.automaticSilentRenew) {
-                    var self = this;
+                    let self = this;
                     this.userManager.events.addAccessTokenExpiring(function() {
                         self.userManager.signinSilent({ scope: config.scope, response_type: config.response_type })
                             .then(function(u) {
@@ -46,7 +46,7 @@
                     return true;
                 }
 
-                var self = this;
+                let self = this;
                 return new Promise((resolve, _reject) => {
                     self.userManager.signinRedirectCallback().then(function(u) {
                         resolve(u !== null);
@@ -70,7 +70,7 @@
                     return this.User;
                 }
 
-                var self = this;
+                let self = this;
                 return new Promise((resolve, _reject) => {
                     self.userManager.getUser().then(function(u) {
                         self.SetCurrentUser(u);
@@ -89,7 +89,7 @@
                     return false;
                 }
 
-                var self = this;
+                let self = this;
                 return new Promise((resolve, _reject) => {
                     self.userManager.signinRedirect();
                     resolve(true);
@@ -101,7 +101,7 @@
                     return false;
                 }
 
-                var self = this;
+                let self = this;
                 return new Promise((resolve, _reject) => {
                     self.userManager.signoutRedirect();
                     return resolve(true);

--- a/src/Blorc.OpenIdConnect/wwwroot/oidc-client-interop.js
+++ b/src/Blorc.OpenIdConnect/wwwroot/oidc-client-interop.js
@@ -104,7 +104,7 @@
                 let self = this;
                 return new Promise((resolve, _reject) => {
                     self.userManager.signoutRedirect();
-                    return resolve(true);
+                    resolve(true);
                 });
             },
             SetCurrentUser: function(u) {

--- a/src/Blorc.OpenIdConnect/wwwroot/oidc-client-interop.js
+++ b/src/Blorc.OpenIdConnect/wwwroot/oidc-client-interop.js
@@ -1,7 +1,7 @@
 ﻿window.BlorcOidc = {
     Navigation: {
-        IsRedirected: function() {
-            return window.performance.navigation.type === 0;
+        IsRedirected: function () {
+            return performance.getEntriesByType("navigation")[0].type === "navigate";
         }
     },
     Client: {


### PR DESCRIPTION
Sonar fixes
- [x] Specifies AttributeUsage on ClaimTypeAttribute
- [x] Reduces cognitive complexity of AsClaims object extension method
- [x] Uses getEntriesByType method to get navigation type instead the deprecated navigation property
- [x] Removes UserManager dependency from Blorc.Core IConfigurationService (Deprecation)
- [x] Improves names of unused parameter names with an underscore character
- [x] Uses 'let' instead 'var' for read-only variables