### PR TITLE
Add user and profile claims

### DIFF
--- a/src/Blorc.OpenIdConnect.DemoApp/Pages/Index.razor
+++ b/src/Blorc.OpenIdConnect.DemoApp/Pages/Index.razor
@@ -12,6 +12,8 @@ Welcome to your new app.
         You are already logged in.
         <br/>
         <br/>
+        <b>Sub:</b> @User?.Profile?.Sub<br/>
+        <b>Username:</b> @User?.Profile?.Username<br/>
         <b>PreferredUsername:</b> @User?.Profile?.PreferredUsername<br/>
         <b>Name:</b> @User?.Profile?.Name<br/>
         <b>Email:</b> @User?.Profile?.Email<br/>

--- a/src/Blorc.OpenIdConnect.Tests/Extensions/ObjectExtensionsFacts.cs
+++ b/src/Blorc.OpenIdConnect.Tests/Extensions/ObjectExtensionsFacts.cs
@@ -2,27 +2,10 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
     using System.Security.Claims;
     using System.Text.Json;
     using NUnit.Framework;
-
-    [SetUpFixture]
-    public class SetupTrace
-    {
-        [OneTimeSetUp]
-        public void StartTest()
-        {
-            Trace.Listeners.Add(new ConsoleTraceListener());
-        }
-
-        [OneTimeTearDown]
-        public void EndTest()
-        {
-            Trace.Flush();
-        }
-    }
 
     [TestFixture]
     public class ObjectExtensionsFacts
@@ -162,10 +145,10 @@
                     AccessToken = "1234567890",
                     Profile = new Profile
                     {
-                        Roles = new[]
-                        {
+                        Roles = 
+                        [
                             "Administrator", "System Administrator"
-                        },
+                        ],
                         Email = "jane.doe@blorc.com",
                         EmailVerified = true,
                         FamilyName = "Doe",

--- a/src/Blorc.OpenIdConnect.Tests/Extensions/ObjectExtensionsFacts.cs
+++ b/src/Blorc.OpenIdConnect.Tests/Extensions/ObjectExtensionsFacts.cs
@@ -20,7 +20,7 @@
                     AccessToken = "1234567890",
                     Profile = new Profile
                     {
-                        Roles = [ "Administrator", "System Administrator" ],
+                        Roles = ["Administrator", "System Administrator"],
                         Email = "jane.doe@blorc.com",
                         EmailVerified = true,
                         FamilyName = "Doe",
@@ -53,7 +53,7 @@
                     Profile = new Profile
                     {
                         Aud = JsonDocument.Parse("\"http://localhost\"").RootElement,
-                        Roles = [ "Administrator", "System Administrator" ],
+                        Roles = ["Administrator", "System Administrator"],
                         Email = "jane.doe@blorc.com",
                         EmailVerified = true,
                         FamilyName = "Doe",
@@ -72,6 +72,7 @@
                 Assert.That(claim, Is.Not.Null);
             }
 
+            [Test]
             public void Collects_Aud_AsClaims_Array()
             {
                 var user = new User<Profile>
@@ -80,7 +81,7 @@
                     Profile = new Profile
                     {
                         Aud = JsonDocument.Parse("[\"http://localhost\", \"http://example.com\"]").RootElement,
-                        Roles = [ "Administrator", "System Administrator" ],
+                        Roles = ["Administrator", "System Administrator"],
                         Email = "jane.doe@blorc.com",
                         EmailVerified = true,
                         FamilyName = "Doe",
@@ -113,7 +114,7 @@
                     Profile = new Profile
                     {
                         Aud = JsonDocument.Parse("\"http://localhost\"").RootElement,
-                        Roles = [ "Administrator", "System Administrator" ],
+                        Roles = ["Administrator", "System Administrator"],
                         Email = "jane.doe@blorc.com",
                         EmailVerified = true,
                         FamilyName = "Doe",
@@ -145,7 +146,7 @@
                     AccessToken = "1234567890",
                     Profile = new Profile
                     {
-                        Roles = 
+                        Roles =
                         [
                             "Administrator", "System Administrator"
                         ],

--- a/src/Blorc.OpenIdConnect.Tests/Extensions/ObjectExtensionsFacts.cs
+++ b/src/Blorc.OpenIdConnect.Tests/Extensions/ObjectExtensionsFacts.cs
@@ -176,7 +176,7 @@
 
                 var claims = complexType.AsClaims().ToList();
 
-                Assert.That(claims.Count, Is.EqualTo(32));
+                Assert.That(claims.Count, Is.EqualTo(30));
             }
 
             public class ComplexType

--- a/src/Blorc.OpenIdConnect.Tests/Extensions/ObjectExtensionsFacts.cs
+++ b/src/Blorc.OpenIdConnect.Tests/Extensions/ObjectExtensionsFacts.cs
@@ -2,9 +2,27 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
     using System.Security.Claims;
+    using System.Text.Json;
     using NUnit.Framework;
+
+    [SetUpFixture]
+    public class SetupTrace
+    {
+        [OneTimeSetUp]
+        public void StartTest()
+        {
+            Trace.Listeners.Add(new ConsoleTraceListener());
+        }
+
+        [OneTimeTearDown]
+        public void EndTest()
+        {
+            Trace.Flush();
+        }
+    }
 
     [TestFixture]
     public class ObjectExtensionsFacts
@@ -19,7 +37,7 @@
                     AccessToken = "1234567890",
                     Profile = new Profile
                     {
-                        Roles = new[] { "Administrator", "System Administrator" },
+                        Roles = [ "Administrator", "System Administrator" ],
                         Email = "jane.doe@blorc.com",
                         EmailVerified = true,
                         FamilyName = "Doe",
@@ -44,15 +62,15 @@
             }
 
             [Test]
-            public void Collects_Claims_From_Each_Item_Of_A_Collection()
+            public void Collects_Aud_AsClaims()
             {
-                var users = new List<User<Profile>>();
                 var user = new User<Profile>
                 {
                     AccessToken = "1234567890",
                     Profile = new Profile
                     {
-                        Roles = new[] { "Administrator", "System Administrator" },
+                        Aud = JsonDocument.Parse("\"http://localhost\"").RootElement,
+                        Roles = [ "Administrator", "System Administrator" ],
                         Email = "jane.doe@blorc.com",
                         EmailVerified = true,
                         FamilyName = "Doe",
@@ -65,12 +83,75 @@
                     TokenType = "Bearer"
                 };
 
+                var claims = user.AsClaims().Where(claim => claim.Type == "aud").ToList();
+                Assert.That(claims.Count, Is.EqualTo(1));
+                var claim = claims.FirstOrDefault(c => c.Value == user.Profile.Aud.GetString());
+                Assert.That(claim, Is.Not.Null);
+            }
+
+            public void Collects_Aud_AsClaims_Array()
+            {
+                var user = new User<Profile>
+                {
+                    AccessToken = "1234567890",
+                    Profile = new Profile
+                    {
+                        Aud = JsonDocument.Parse("[\"http://localhost\", \"http://example.com\"]").RootElement,
+                        Roles = [ "Administrator", "System Administrator" ],
+                        Email = "jane.doe@blorc.com",
+                        EmailVerified = true,
+                        FamilyName = "Doe",
+                        GivenName = "Jane",
+                        Name = "Jane Doe",
+                        PreferredUsername = "jane.doe"
+                    },
+                    ExpiresAt = 10,
+                    SessionState = "alskjdhflaskjdhflaksjdhqwpoyir",
+                    TokenType = "Bearer"
+                };
+
+                var claims = user.AsClaims().Where(claim => claim.Type == "aud").ToList();
+                Assert.That(claims.Count, Is.EqualTo(2));
+
+                foreach (var audience in user.Profile.Audiences)
+                {
+                    var claim = claims.FirstOrDefault(c => c.Value == audience);
+                    Assert.That(claim, Is.Not.Null);
+                }
+            }
+
+            [Test]
+            public void Collects_Claims_From_Each_Item_Of_A_Collection()
+            {
+                var users = new List<User<Profile>>();
+                var user = new User<Profile>
+                {
+                    AccessToken = "1234567890",
+                    Profile = new Profile
+                    {
+                        Aud = JsonDocument.Parse("\"http://localhost\"").RootElement,
+                        Roles = [ "Administrator", "System Administrator" ],
+                        Email = "jane.doe@blorc.com",
+                        EmailVerified = true,
+                        FamilyName = "Doe",
+                        GivenName = "Jane",
+                        Name = "Jane Doe",
+                        PreferredUsername = "jane.doe"
+                    },
+                    ExpiresAt = 10,
+                    SessionState = "alskjdhflaskjdhflaksjdhqwpoyir",
+                    TokenType = "Bearer",
+                    RefreshToken = "alskjdhflaskjdhflaksjdhqwpoyir",
+                    IdToken = "alskjdhflaskjdhflaksjdhqwpoyir",
+                    Scope = "openid profile email"
+                };
+
                 users.Add(user);
                 users.Add(user);
 
                 var claims = users.AsClaims().ToList();
 
-                Assert.That(claims.Count, Is.EqualTo(14));
+                Assert.That(claims.Count, Is.EqualTo(28));
             }
 
             [Test]
@@ -112,7 +193,7 @@
 
                 var claims = complexType.AsClaims().ToList();
 
-                Assert.That(claims.Count, Is.EqualTo(18));
+                Assert.That(claims.Count, Is.EqualTo(32));
             }
 
             public class ComplexType

--- a/src/Blorc.OpenIdConnect.Tests/Extensions/TypeExtensionsFacts.cs
+++ b/src/Blorc.OpenIdConnect.Tests/Extensions/TypeExtensionsFacts.cs
@@ -1,7 +1,6 @@
 ﻿namespace Blorc.OpenIdConnect.Tests
 {
     using System;
-    using Blorc.OpenIdConnect.Tests.Services;
     using NUnit.Framework;
 
     [TestFixture]

--- a/src/Blorc.OpenIdConnect.Tests/Models/UserFacts.cs
+++ b/src/Blorc.OpenIdConnect.Tests/Models/UserFacts.cs
@@ -1,0 +1,96 @@
+namespace Blorc.OpenIdConnect.Tests;
+
+using System.Collections.Generic;
+using System.Text.Json;
+using NUnit.Framework;
+using Is = NUnit.DeepObjectCompare.Is;
+
+[TestFixture]
+public class UserFacts
+{
+    public class JsonFacts
+    {
+        [Test]
+        public void Can_Deserialize_User()
+        {
+            var json = @"{
+                ""access_token"": ""access_token_value"",
+                ""expires_at"": 10,
+                ""id_token"": ""id_token_value"",
+                ""profile"": {
+                    ""aud"": ""https://localhost:5001"",
+                    ""roles"": [ ""Administrator"", ""System Administrator"" ],
+                    ""email"": ""jane.doe@blorc.com"",
+                    ""email_verified"": true,
+                    ""name"": ""Jane Doe"",
+                    ""preferred_username"": ""jane.doe"",
+                    ""sub"": ""1234567890""
+                },
+                ""refresh_token"": ""refresh_token_value"",
+                ""scope"": ""openid profile email roles"",
+                ""session_state"": ""session_state_value"",
+                ""token_type"": ""Bearer""
+            }";
+
+            var user = JsonSerializer.Deserialize<User<Profile>>(json);
+
+            Assert.That(user, Is.Not.Null);
+            Assert.That(user.AccessToken, Is.EqualTo("access_token_value"));
+            Assert.That(user.ExpiresAt, Is.EqualTo(10));
+            Assert.That(user.IdToken, Is.EqualTo("id_token_value"));
+            Assert.That(user.Profile, Is.Not.Null);
+            Assert.That(user.Profile!.Audiences, Is.DeepEqualTo(new[] { "https://localhost:5001" }));
+            Assert.That(user.Profile!.Roles, Is.DeepEqualTo(new[] { "Administrator", "System Administrator" }));
+            Assert.That(user.Profile!.Email, Is.EqualTo("jane.doe@blorc.com"));
+            Assert.That(user.Profile!.EmailVerified, Is.True);
+            Assert.That(user.Profile!.Name, Is.EqualTo("Jane Doe"));
+            Assert.That(user.Profile!.PreferredUsername, Is.EqualTo("jane.doe"));
+            Assert.That(user.Profile!.Sub, Is.EqualTo("1234567890"));
+            Assert.That(user.RefreshToken, Is.EqualTo("refresh_token_value"));
+            Assert.That(user.Scope, Is.EqualTo("openid profile email roles"));
+            Assert.That(user.Scopes, Is.DeepEqualTo(new[] { "openid", "profile", "email", "roles" }));
+            Assert.That(user.SessionState, Is.EqualTo("session_state_value"));
+            Assert.That(user.TokenType, Is.EqualTo("Bearer"));
+        }
+
+        [Test]
+        public void Can_Deserialize_Additional_Data() {
+            var json = @"{
+                ""access_token"": ""access_token_value"",
+                ""expires_at"": 10,
+                ""profile"": {
+                    ""aud"": ""https://localhost:5001"",
+                    ""sub"": ""1234567890"",
+                    ""some_additional_data"": ""some_additional_data_value""
+                },
+                ""token_type"": ""Bearer""
+            }";
+
+            var user = JsonSerializer.Deserialize<User<Profile>>(json);
+
+            Assert.That(user, Is.Not.Null);
+            Assert.That(user.Profile!.AdditionalData, Is.Not.Null);
+            Assert.That(user.Profile!.AdditionalData!["some_additional_data"].GetString(), Is.EqualTo("some_additional_data_value"));
+        }
+
+        [Test]
+        public void Can_Deserialize_Aud_Array() {
+            var json = @"{
+                ""access_token"": ""access_token_value"",
+                ""expires_at"": 10,
+                ""profile"": {
+                    ""aud"": [ ""https://localhost:5001"", ""https://localhost:5002"" ],
+                    ""sub"": ""1234567890""
+                },
+                ""token_type"": ""Bearer""
+            }";
+
+            var user = JsonSerializer.Deserialize<User<Profile>>(json);
+
+            Assert.That(user, Is.Not.Null);
+            Assert.That(user.Profile!.Audiences, Is.DeepEqualTo(new[] { "https://localhost:5001", "https://localhost:5002" }));
+        }
+    }
+}
+
+        

--- a/src/Blorc.OpenIdConnect.Tests/Models/UserFacts.cs
+++ b/src/Blorc.OpenIdConnect.Tests/Models/UserFacts.cs
@@ -59,7 +59,6 @@ public class UserFacts
                 ""access_token"": ""access_token_value"",
                 ""expires_at"": 10,
                 ""profile"": {
-                    ""aud"": ""https://localhost:5001"",
                     ""sub"": ""1234567890"",
                     ""some_additional_data"": ""some_additional_data_value""
                 },
@@ -69,6 +68,7 @@ public class UserFacts
             var user = JsonSerializer.Deserialize<User<Profile>>(json);
 
             Assert.That(user, Is.Not.Null);
+            Assert.That(user.Profile!.Audiences, Is.Empty);
             Assert.That(user.Profile!.AdditionalData, Is.Not.Null);
             Assert.That(user.Profile!.AdditionalData!["some_additional_data"].GetString(), Is.EqualTo("some_additional_data_value"));
         }

--- a/src/Blorc.OpenIdConnect.Tests/Models/UserFacts.cs
+++ b/src/Blorc.OpenIdConnect.Tests/Models/UserFacts.cs
@@ -1,6 +1,5 @@
 namespace Blorc.OpenIdConnect.Tests;
 
-using System.Collections.Generic;
 using System.Text.Json;
 using NUnit.Framework;
 using Is = NUnit.DeepObjectCompare.Is;
@@ -54,7 +53,8 @@ public class UserFacts
         }
 
         [Test]
-        public void Can_Deserialize_Additional_Data() {
+        public void Can_Deserialize_Additional_Data()
+        {
             var json = @"{
                 ""access_token"": ""access_token_value"",
                 ""expires_at"": 10,
@@ -74,7 +74,8 @@ public class UserFacts
         }
 
         [Test]
-        public void Can_Deserialize_Aud_Array() {
+        public void Can_Deserialize_Aud_Array()
+        {
             var json = @"{
                 ""access_token"": ""access_token_value"",
                 ""expires_at"": 10,

--- a/src/Blorc.OpenIdConnect.Tests/Models/UserFacts.cs
+++ b/src/Blorc.OpenIdConnect.Tests/Models/UserFacts.cs
@@ -92,5 +92,3 @@ public class UserFacts
         }
     }
 }
-
-        

--- a/src/Blorc.OpenIdConnect.Tests/PublicApiFacts.Blorc_OpenIdConnect_HasNoBreakingChanges_Async.verified.txt
+++ b/src/Blorc.OpenIdConnect.Tests/PublicApiFacts.Blorc_OpenIdConnect_HasNoBreakingChanges_Async.verified.txt
@@ -175,6 +175,9 @@ namespace Blorc.OpenIdConnect
         [Blorc.OpenIdConnect.ClaimType("sub")]
         [System.Text.Json.Serialization.JsonPropertyName("sub")]
         public string Sub { get; set; }
+        [Blorc.OpenIdConnect.ClaimType("username")]
+        [System.Text.Json.Serialization.JsonPropertyName("username")]
+        public string? Username { get; set; }
     }
     public class PromiseHandlerContext
     {
@@ -255,6 +258,7 @@ namespace Blorc.OpenIdConnect
         public System.Collections.Generic.IEnumerable<string> Roles { get; }
         [System.Text.Json.Serialization.JsonPropertyName("scope")]
         public string? Scope { get; set; }
+        public string[] Scopes { get; }
         [System.Text.Json.Serialization.JsonPropertyName("session_state")]
         public string? SessionState { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("token_type")]

--- a/src/Blorc.OpenIdConnect.Tests/PublicApiFacts.Blorc_OpenIdConnect_HasNoBreakingChanges_Async.verified.txt
+++ b/src/Blorc.OpenIdConnect.Tests/PublicApiFacts.Blorc_OpenIdConnect_HasNoBreakingChanges_Async.verified.txt
@@ -55,6 +55,7 @@ namespace Blorc.OpenIdConnect
     }
     public static class JsonElementExtensions
     {
+        public static System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> AsClaims(this System.Text.Json.JsonElement element, string claimType = "") { }
         public static TObject? ToObject<TObject>(this System.Text.Json.JsonElement element, System.Text.Json.JsonSerializerOptions? options = null) { }
     }
     public static class ObjectExtensions
@@ -117,26 +118,63 @@ namespace Blorc.OpenIdConnect
     public class Profile
     {
         public Profile() { }
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.Dictionary<string, System.Text.Json.JsonElement>? AdditionalData { get; set; }
+        [Blorc.OpenIdConnect.ClaimType("aud")]
+        [System.Text.Json.Serialization.JsonPropertyName("aud")]
+        public System.Text.Json.JsonElement Aud { get; set; }
+        public string[] Audiences { get; }
         [Blorc.OpenIdConnect.ClaimType("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress")]
         [System.Text.Json.Serialization.JsonPropertyName("email")]
         public string? Email { get; set; }
+        [Blorc.OpenIdConnect.ClaimType("email_verified")]
         [System.Text.Json.Serialization.JsonPropertyName("email_verified")]
         public bool EmailVerified { get; set; }
+        [Blorc.OpenIdConnect.ClaimType("http://schemas.microsoft.com/ws/2008/06/identity/claims/expiration")]
+        [System.Text.Json.Serialization.JsonPropertyName("exp")]
+        public long Exp { get; set; }
         [Blorc.OpenIdConnect.ClaimType("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname")]
         [System.Text.Json.Serialization.JsonPropertyName("family_name")]
         public string? FamilyName { get; set; }
         [Blorc.OpenIdConnect.ClaimType("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname")]
         [System.Text.Json.Serialization.JsonPropertyName("given_name")]
         public string? GivenName { get; set; }
+        [Blorc.OpenIdConnect.ClaimType("iat")]
+        [System.Text.Json.Serialization.JsonPropertyName("iat")]
+        public long Iat { get; set; }
+        [Blorc.OpenIdConnect.ClaimType("iss")]
+        [System.Text.Json.Serialization.JsonPropertyName("iss")]
+        public string Iss { get; set; }
+        [Blorc.OpenIdConnect.ClaimType("jti")]
+        [System.Text.Json.Serialization.JsonPropertyName("jti")]
+        public string? Jti { get; set; }
         [Blorc.OpenIdConnect.ClaimType("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name")]
         [System.Text.Json.Serialization.JsonPropertyName("name")]
         public string? Name { get; set; }
+        [Blorc.OpenIdConnect.ClaimType("nickname")]
+        [System.Text.Json.Serialization.JsonPropertyName("nickname")]
+        public string? Nickname { get; set; }
+        [Blorc.OpenIdConnect.ClaimType("nonce")]
+        [System.Text.Json.Serialization.JsonPropertyName("nonce")]
+        public string? Nonce { get; set; }
+        [Blorc.OpenIdConnect.ClaimType("phone_number")]
+        [System.Text.Json.Serialization.JsonPropertyName("phone_number")]
+        public string? PhoneNumber { get; set; }
+        [Blorc.OpenIdConnect.ClaimType("phone_number_verified")]
+        [System.Text.Json.Serialization.JsonPropertyName("phone_number_verified")]
+        public bool PhoneNumberVerified { get; set; }
+        [Blorc.OpenIdConnect.ClaimType("picture")]
+        [System.Text.Json.Serialization.JsonPropertyName("picture")]
+        public string? Picture { get; set; }
         [Blorc.OpenIdConnect.ClaimType("preferred_username")]
         [System.Text.Json.Serialization.JsonPropertyName("preferred_username")]
         public string? PreferredUsername { get; set; }
         [Blorc.OpenIdConnect.ClaimType("http://schemas.microsoft.com/ws/2008/06/identity/claims/role")]
         [System.Text.Json.Serialization.JsonPropertyName("roles")]
         public string[]? Roles { get; set; }
+        [Blorc.OpenIdConnect.ClaimType("sub")]
+        [System.Text.Json.Serialization.JsonPropertyName("sub")]
+        public string Sub { get; set; }
     }
     public class PromiseHandlerContext
     {
@@ -207,10 +245,16 @@ namespace Blorc.OpenIdConnect
         public string? AccessToken { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("expires_at")]
         public long ExpiresAt { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("id_token")]
+        public string IdToken { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("profile")]
         public TProfile Profile { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("refresh_token")]
+        public string? RefreshToken { get; set; }
         [System.Text.Json.Serialization.JsonIgnore]
         public System.Collections.Generic.IEnumerable<string> Roles { get; }
+        [System.Text.Json.Serialization.JsonPropertyName("scope")]
+        public string? Scope { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("session_state")]
         public string? SessionState { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("token_type")]

--- a/src/Blorc.OpenIdConnect.Tests/Services/UserManagerFacts.cs
+++ b/src/Blorc.OpenIdConnect.Tests/Services/UserManagerFacts.cs
@@ -63,7 +63,7 @@
                     AccessToken = "1234567890",
                     Profile = new Profile
                                 {
-                                    Roles = new[] { "Administrator", "System Administrator" },
+                                    Roles = [ "Administrator", "System Administrator" ],
                                     Email = "jane.doe@blorc.com",
                                     EmailVerified = true,
                                     FamilyName = "Doe",
@@ -93,7 +93,7 @@
 
                 var user = await userManager.GetUserAsync<User<Profile>>();
 
-                Assert.That(user, Is.DeepEqualTo(expectedUser));
+                Assert.That(JsonSerializer.Serialize(user), Is.EqualTo(JsonSerializer.Serialize(expectedUser)));
             }
 
             [Test]
@@ -110,7 +110,7 @@
                     AccessToken = "1234567890",
                     Profile = new Profile
                                 {
-                                    Roles = new[] { "Administrator", "System Administrator" },
+                                    Roles = [ "Administrator", "System Administrator" ],
                                     Email = "jane.doe@blorc.com",
                                     EmailVerified = true,
                                     FamilyName = "Doe",

--- a/src/Blorc.OpenIdConnect/Extensions/JsonElementExtensions.cs
+++ b/src/Blorc.OpenIdConnect/Extensions/JsonElementExtensions.cs
@@ -7,62 +7,63 @@ namespace Blorc.OpenIdConnect
 
     public static partial class JsonElementExtensions
     {
-      public static IEnumerable<Claim> AsClaims(this JsonElement element, string claimType = "") {
-        switch (element.ValueKind)
+        public static IEnumerable<Claim> AsClaims(this JsonElement element, string claimType = "")
         {
-            case JsonValueKind.Object:
-                {
-                    using var enumerator = element.EnumerateObject();
-                    foreach (JsonProperty property in enumerator)
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Object:
                     {
-                        // For objects, recursively process each property.
-                        // Use the property name as part of the claim type.
-                        string nestedClaimType = string.IsNullOrEmpty(claimType) ? property.Name : $"{claimType}.{property.Name}";
-                        foreach (var claim in AsClaims(property.Value, nestedClaimType))
+                        using var enumerator = element.EnumerateObject();
+                        foreach (JsonProperty property in enumerator)
                         {
-                            yield return claim;
+                            // For objects, recursively process each property.
+                            // Use the property name as part of the claim type.
+                            string nestedClaimType = string.IsNullOrEmpty(claimType) ? property.Name : $"{claimType}.{property.Name}";
+                            foreach (var claim in AsClaims(property.Value, nestedClaimType))
+                            {
+                                yield return claim;
+                            }
                         }
                     }
-                }
-                break;
+                    break;
 
-            case JsonValueKind.Array:
-                {
-                    using var enumerator = element.EnumerateArray();
-                    int index = 0;
-                    foreach (JsonElement item in enumerator)
+                case JsonValueKind.Array:
                     {
-                        // For arrays, process each item and use the index in the claim type.
-                        string indexedClaimType = $"{claimType}[{index}]";
-                        foreach (var claim in AsClaims(item, indexedClaimType))
+                        using var enumerator = element.EnumerateArray();
+                        int index = 0;
+                        foreach (JsonElement item in enumerator)
                         {
-                            yield return claim;
+                            // For arrays, process each item and use the index in the claim type.
+                            string indexedClaimType = $"{claimType}[{index}]";
+                            foreach (var claim in AsClaims(item, indexedClaimType))
+                            {
+                                yield return claim;
+                            }
+                            index++;
                         }
-                        index++;
                     }
-                }
-                break;
+                    break;
 
-            case JsonValueKind.String:
-                yield return new Claim(claimType, element.GetString()!);
-                break;
+                case JsonValueKind.String:
+                    yield return new Claim(claimType, element.GetString()!);
+                    break;
 
-            case JsonValueKind.Number:
-                yield return new Claim(claimType, element.GetRawText());
-                break;
+                case JsonValueKind.Number:
+                    yield return new Claim(claimType, element.GetRawText());
+                    break;
 
-            case JsonValueKind.True:
-            case JsonValueKind.False:
-                yield return new Claim(claimType, element.GetBoolean().ToString());
-                break;
+                case JsonValueKind.True:
+                case JsonValueKind.False:
+                    yield return new Claim(claimType, element.GetBoolean().ToString());
+                    break;
 
-            case JsonValueKind.Null:
-                // Ignore null values.
-                break;
+                case JsonValueKind.Null:
+                    // Ignore null values.
+                    break;
 
-            default:
-                throw new InvalidOperationException($"Unknown JSON token: {element.ValueKind}");
+                default:
+                    throw new InvalidOperationException($"Unknown JSON token: {element.ValueKind}");
+            }
         }
-      }
     }
 }

--- a/src/Blorc.OpenIdConnect/Extensions/JsonElementExtensions.cs
+++ b/src/Blorc.OpenIdConnect/Extensions/JsonElementExtensions.cs
@@ -1,0 +1,68 @@
+namespace Blorc.OpenIdConnect
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Security.Claims;
+    using System.Text.Json;
+
+    public static partial class JsonElementExtensions
+    {
+      public static IEnumerable<Claim> AsClaims(this JsonElement element, string claimType = "") {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                {
+                    using var enumerator = element.EnumerateObject();
+                    foreach (JsonProperty property in enumerator)
+                    {
+                        // For objects, recursively process each property.
+                        // Use the property name as part of the claim type.
+                        string nestedClaimType = string.IsNullOrEmpty(claimType) ? property.Name : $"{claimType}.{property.Name}";
+                        foreach (var claim in AsClaims(property.Value, nestedClaimType))
+                        {
+                            yield return claim;
+                        }
+                    }
+                }
+                break;
+
+            case JsonValueKind.Array:
+                {
+                    using var enumerator = element.EnumerateArray();
+                    int index = 0;
+                    foreach (JsonElement item in enumerator)
+                    {
+                        // For arrays, process each item and use the index in the claim type.
+                        string indexedClaimType = $"{claimType}[{index}]";
+                        foreach (var claim in AsClaims(item, indexedClaimType))
+                        {
+                            yield return claim;
+                        }
+                        index++;
+                    }
+                }
+                break;
+
+            case JsonValueKind.String:
+                yield return new Claim(claimType, element.GetString()!);
+                break;
+
+            case JsonValueKind.Number:
+                yield return new Claim(claimType, element.GetRawText());
+                break;
+
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+                yield return new Claim(claimType, element.GetBoolean().ToString());
+                break;
+
+            case JsonValueKind.Null:
+                // Ignore null values.
+                break;
+
+            default:
+                throw new InvalidOperationException($"Unknown JSON token: {element.ValueKind}");
+        }
+      }
+    }
+}

--- a/src/Blorc.OpenIdConnect/Extensions/ObjectExtensions.cs
+++ b/src/Blorc.OpenIdConnect/Extensions/ObjectExtensions.cs
@@ -5,6 +5,7 @@
     using System.Collections.Generic;
     using System.Reflection;
     using System.Security.Claims;
+    using System.Text.Json;
     using Blorc.Reflection;
 
     public static class ObjectExtensions
@@ -22,6 +23,11 @@
             if (instance.GetType().IsPrimitiveEx())
             {
                 return instance.EnumClaimsFromPrimitive(claimType);
+            }
+
+            if (instance is JsonElement jsonElement)
+            {
+                return jsonElement.AsClaims(claimType);
             }
 
             return instance.EnumClaimsFromObjectProperties();
@@ -70,6 +76,3 @@
         }
     }
 }
-
-
-

--- a/src/Blorc.OpenIdConnect/Models/Profile.cs
+++ b/src/Blorc.OpenIdConnect/Models/Profile.cs
@@ -13,7 +13,7 @@
         {
             get;
             set;
-        } = JsonDocument.Parse("\"\"").RootElement;
+        } = JsonDocument.Parse("[]").RootElement;
 
         public string[] Audiences
         {

--- a/src/Blorc.OpenIdConnect/Models/Profile.cs
+++ b/src/Blorc.OpenIdConnect/Models/Profile.cs
@@ -1,10 +1,45 @@
 ﻿namespace Blorc.OpenIdConnect
 {
+    using System.Collections.Generic;
     using System.Security.Claims;
+    using System.Text.Json;
     using System.Text.Json.Serialization;
 
     public class Profile
     {
+        [ClaimType("aud")]
+        [JsonPropertyName("aud")]
+        public JsonElement Aud
+        {
+            get;
+            set;
+        } = JsonDocument.Parse("\"\"").RootElement;
+
+        public string[] Audiences
+        {
+            get
+            {
+                if (Aud.ValueKind == JsonValueKind.Array)
+                {
+                    var result = new List<string>();
+                    using var enumerator = Aud.EnumerateArray();
+
+                    foreach (var item in enumerator)
+                    {
+                        result.Add(item.GetString()!);
+                    }
+
+                    return result.ToArray();
+                } 
+                else if (Aud.ValueKind == JsonValueKind.String)
+                {
+                    return [ Aud.GetString()! ];
+                }
+
+                return [];
+            }
+        }
+
         [ClaimType(ClaimTypes.Email)]
         [JsonPropertyName("email")]
         public string? Email
@@ -13,8 +48,17 @@
             set;
         }
 
+        [ClaimType("email_verified")]
         [JsonPropertyName("email_verified")]
         public bool EmailVerified
+        {
+            get;
+            set;
+        }
+
+        [ClaimType(ClaimTypes.Expiration)]
+        [JsonPropertyName("exp")]
+        public long Exp
         {
             get;
             set;
@@ -36,9 +80,73 @@
             set;
         }
 
+        [ClaimType("iat")]
+        [JsonPropertyName("iat")]
+        public long Iat
+        {
+            get;
+            set;
+        }
+
+        [ClaimType("iss")]
+        [JsonPropertyName("iss")]
+        public string Iss
+        {
+            get;
+            set;
+        } = string.Empty;
+
+        [ClaimType("jti")]
+        [JsonPropertyName("jti")]
+        public string? Jti
+        {
+            get;
+            set;
+        }
+
         [ClaimType(ClaimTypes.Name)]
         [JsonPropertyName("name")]
         public string? Name
+        {
+            get;
+            set;
+        }
+
+        [ClaimType("nickname")]
+        [JsonPropertyName("nickname")]
+        public string? Nickname
+        {
+            get;
+            set;
+        }
+
+        [ClaimType("nonce")]
+        [JsonPropertyName("nonce")]
+        public string? Nonce
+        {
+            get;
+            set;
+        }
+
+        [ClaimType("phone_number")]
+        [JsonPropertyName("phone_number")]
+        public string? PhoneNumber
+        {
+            get;
+            set;
+        }
+
+        [ClaimType("phone_number_verified")]
+        [JsonPropertyName("phone_number_verified")]
+        public bool PhoneNumberVerified
+        {
+            get;
+            set;
+        }
+
+        [ClaimType("picture")]
+        [JsonPropertyName("picture")]
+        public string? Picture
         {
             get;
             set;
@@ -55,6 +163,21 @@
         [ClaimType(ClaimTypes.Role)]
         [JsonPropertyName("roles")]
         public string[]? Roles
+        {
+            get;
+            set;
+        }
+
+        [ClaimType("sub")]
+        [JsonPropertyName("sub")]
+        public string Sub
+        {
+            get;
+            set;
+        } = string.Empty;
+
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement>? AdditionalData
         {
             get;
             set;

--- a/src/Blorc.OpenIdConnect/Models/Profile.cs
+++ b/src/Blorc.OpenIdConnect/Models/Profile.cs
@@ -176,6 +176,14 @@
             set;
         } = string.Empty;
 
+        [ClaimType("username")]
+        [JsonPropertyName("username")]
+        public string? Username
+        {
+            get;
+            set;
+        }
+
         [JsonExtensionData]
         public Dictionary<string, JsonElement>? AdditionalData
         {

--- a/src/Blorc.OpenIdConnect/Models/User.cs
+++ b/src/Blorc.OpenIdConnect/Models/User.cs
@@ -49,6 +49,19 @@
             set;
         }
 
+        public string[] Scopes
+        {
+            get
+            {
+                if (Scope is not null)
+                {
+                    return Scope.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                }
+
+                return Array.Empty<string>();
+            }
+        }
+
 
         [JsonPropertyName("session_state")]
         public string? SessionState

--- a/src/Blorc.OpenIdConnect/Models/User.cs
+++ b/src/Blorc.OpenIdConnect/Models/User.cs
@@ -21,12 +21,34 @@
             set;
         }
 
+        [JsonPropertyName("id_token")]
+        public string IdToken
+        {
+            get;
+            set;
+        } = string.Empty;
+
         [JsonPropertyName("profile")]
         public TProfile? Profile
         {
             get;
             set;
         }
+
+        [JsonPropertyName("refresh_token")]
+        public string? RefreshToken
+        {
+            get;
+            set;
+        }
+
+        [JsonPropertyName("scope")]
+        public string? Scope
+        {
+            get;
+            set;
+        }
+
 
         [JsonPropertyName("session_state")]
         public string? SessionState

--- a/src/Blorc.OpenIdConnect/Services/Extensions/JsonElementExtensions.cs
+++ b/src/Blorc.OpenIdConnect/Services/Extensions/JsonElementExtensions.cs
@@ -4,7 +4,7 @@
     using System.Buffers;
     using System.Text.Json;
 
-    public static class JsonElementExtensions
+    public static partial class JsonElementExtensions
     {
         public static TObject? ToObject<TObject>(this JsonElement element, JsonSerializerOptions? options = null)
         {


### PR DESCRIPTION
### Description of Change ###

**Models**

1. Extend `User` and `Profile` class by adding claims defined in `oidc-client-ts`:
  - `User` is mapped to [`User`](https://authts.github.io/oidc-client-ts/classes/User.html)
  - `Profile` is mapped to [`IdTokenClaims`](https://authts.github.io/oidc-client-ts/interfaces/IdTokenClaims.html)
2. Add `AdditionalData` property in `Profile` to allow unknown properties in the ID token, as identity providers may add new claims from time to time.

**Extenstions**

Support `AsClaims` for `JsonElement`.

### Issues Resolved ### 

<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

It providers a better dev experience for integrating various identity providers. E.g. some developers may need to read the `sub` claim to handle user ID.

### API Changes ###

<!-- List all API changes here (or just put None) -->
 
None. I considered aligning nullable definitions, for example, making `AccessToken` required for `User`, but it appears to be a breaking change. So I've decided to leave them as they are.

### Behavioral Changes ###

<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###

<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

- Updated and added unit tests for JSON and claim deserialization.
  <img width="927" alt="image" src="https://github.com/WildGums/Blorc.OpenIdConnect/assets/14722250/ff325cca-b04e-4e75-891a-9753588ac7c1">

- Tested locally with Logto, the sign-in flow works as expected.
  <img width="300" alt="image" src="https://github.com/WildGums/Blorc.OpenIdConnect/assets/14722250/c9394266-0991-4da1-8afb-af6b89030760">

### PR Checklist ###

- [x] I have included examples or tests
- [ ] I have updated the change log (didn't find)
- [ ] I am listed in the CONTRIBUTORS file (didn't find)
- [x] Changes adhere to coding standard
- [x] I checked the licenses of Third Party software and discussed new dependencies with at least 1 other team member